### PR TITLE
Windows build: fix narrowing error for WaitForSingleObject

### DIFF
--- a/contrib/epee/include/console_handler.h
+++ b/contrib/epee/include/console_handler.h
@@ -196,7 +196,7 @@ namespace epee
         if (m_read_status == state_cancelled)
           return false;
 
-        int retval = ::WaitForSingleObject(::GetStdHandle(STD_INPUT_HANDLE), 100);
+        DWORD retval = ::WaitForSingleObject(::GetStdHandle(STD_INPUT_HANDLE), 100);
         switch (retval)
         {
           case WAIT_FAILED:


### PR DESCRIPTION
`WaitForSingleObject` returns a `DWORD`, not an int, so assign `retval` as such and it should fix the error.